### PR TITLE
CORE-477 Make File::rename() overwrite an existing file on SSH

### DIFF
--- a/src/IVT/System/_Internal/SSH.php
+++ b/src/IVT/System/_Internal/SSH.php
@@ -127,7 +127,7 @@ class SSHFile extends FOpenWrapperFile {
     }
 
     protected function renameImpl($to) {
-        Assert::true(ssh2_sftp_rename($this->sftp, $this->absolutePath(), $to));
+        $this->ssh->execArgs(array('mv', '-T', $this->path(), $to));
     }
 
     function realpath() {


### PR DESCRIPTION
According to the SFTP protocol `rename` doesn't overwrite an existing file, even though that's what the POSIX system call does, so we have to use the `mv` command instead.
