### PR TITLE
Remove type hints on Loggable so it can be implemented by Hack code transpiled with h2tp

### DIFF
--- a/src/IVT/System/Loggable.php
+++ b/src/IVT/System/Loggable.php
@@ -14,14 +14,14 @@ interface Loggable {
      * Return a logging version of this class.
      * @param LoggerInterface $logger
      * @param string          $level
-     * @return self
+     * @return Loggable
      */
-    function wrapLogging(LoggerInterface $logger, $level = LogLevel::DEBUG);
+    function wrapLogging($logger, $level = LogLevel::DEBUG);
 
     /**
      * Apply whatever logging this instance has to the given instance.
-     * @param self $loggable
-     * @return self
+     * @param Loggable $loggable
+     * @return Loggable
      */
-    function applyLogging(Loggable $loggable);
+    function applyLogging($loggable);
 }

--- a/src/IVT/System/System.php
+++ b/src/IVT/System/System.php
@@ -40,7 +40,7 @@ abstract class System implements FileSystem, Loggable {
      * @param string          $level
      * @return System
      */
-    final function wrapLogging(LoggerInterface $log, $level = LogLevel::DEBUG) {
+    final function wrapLogging($log, $level = LogLevel::DEBUG) {
         return new LoggingSystem($this, $log, $level);
     }
 
@@ -249,7 +249,7 @@ abstract class System implements FileSystem, Loggable {
      */
     abstract function describe();
 
-    function applyLogging(Loggable $loggable) {
+    function applyLogging($loggable) {
         return $loggable;
     }
 }

--- a/src/IVT/System/_Internal/Logging.php
+++ b/src/IVT/System/_Internal/Logging.php
@@ -358,7 +358,7 @@ class LoggingSystem extends WrappedSystem {
         return $result;
     }
 
-    function applyLogging(Loggable $loggable) {
+    function applyLogging($loggable) {
         return parent::applyLogging($loggable)->wrapLogging($this->logger->getInnerLogger(), $this->level);
     }
 

--- a/src/IVT/System/_Internal/Wrapped.php
+++ b/src/IVT/System/_Internal/Wrapped.php
@@ -164,7 +164,7 @@ class WrappedSystem extends System {
         return $this->system->forwardPort($host, $port);
     }
 
-    function applyLogging(Loggable $loggable) {
+    function applyLogging($loggable) {
         return $this->system->applyLogging($loggable);
     }
 }


### PR DESCRIPTION
This is necessary because PHP enforces that method signatures are compatible with implemented interfaces when a class is loaded.

In Hack, the Hack typechecker serves this role instead (and more correctly), but the output of the `h2tp` transpiler doesn't include the type annotations (which it can't generally because Hack's type system is much more expressive than PHP's), causing PHP to bark about method compatibility when the class is loaded.